### PR TITLE
Fix endless rebooting caused by IPQ5018 nvmem read

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5000-ax3000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5000-ax3000.dts
@@ -162,22 +162,6 @@
 	status = "okay";
 };
 
-&{/thermal-zones/gephy-thermal} {
-	/*
-	 * This inherited IPQ5018 zone reports a bogus critical reading on
-	 * IPQ5000-based Redmi AX3000 early in boot and forces shutdown.
-	 */
-	status = "disabled";
-};
-
-&{/thermal-zones/top-glue-thermal} {
-	/*
-	 * This inherited IPQ5018 zone reports a bogus critical reading on
-	 * IPQ5000-based Redmi AX3000 early in boot and forces shutdown.
-	 */
-	status = "disabled";
-};
-
 &soc {
 	leds {
 		compatible = "gpio-leds";

--- a/target/linux/qualcommax/patches-6.6/0155-revert-nvmem-qfprom-switch-to-4-byte-aligned-reads.patch
+++ b/target/linux/qualcommax/patches-6.6/0155-revert-nvmem-qfprom-switch-to-4-byte-aligned-reads.patch
@@ -1,0 +1,50 @@
+--- a/drivers/nvmem/qfprom.c
++++ b/drivers/nvmem/qfprom.c
+@@ -321,30 +321,17 @@
+ 			unsigned int reg, void *_val, size_t bytes)
+ {
+ 	struct qfprom_priv *priv = context;
+-	u32 *val = _val;
++	u8 *val = _val;
+ 	void __iomem *base = priv->qfpcorrected;
+-	int words = DIV_ROUND_UP(bytes, sizeof(u32));
+ 	int i;
+ 
+ 	if (read_raw_data && priv->qfpraw)
+ 		base = priv->qfpraw;
+ 
+-	for (i = 0; i < words; i++)
+-		*val++ = readl(base + reg + i * sizeof(u32));
++	for (i = 0; i < bytes; i++)
++		*val++ = readb(base + reg + i);
+ 
+ 	return 0;
+-}
+-
+-/* Align reads to word boundary */
+-static void qfprom_fixup_dt_cell_info(struct nvmem_device *nvmem,
+-				      struct nvmem_cell_info *cell)
+-{
+-	unsigned int byte_offset = cell->offset % sizeof(u32);
+-
+-	cell->bit_offset += byte_offset * BITS_PER_BYTE;
+-	cell->offset -= byte_offset;
+-	if (byte_offset && !cell->nbits)
+-		cell->nbits = cell->bytes * BITS_PER_BYTE;
+ }
+ 
+ static void qfprom_runtime_disable(void *data)
+@@ -371,11 +358,10 @@
+ 	struct nvmem_config econfig = {
+ 		.name = "qfprom",
+ 		.add_legacy_fixed_of_cells = true,
+-		.stride = 4,
+-		.word_size = 4,
++		.stride = 1,
++		.word_size = 1,
+ 		.id = NVMEM_DEVID_AUTO,
+ 		.reg_read = qfprom_reg_read,
+-		.fixup_dt_cell_info = qfprom_fixup_dt_cell_info,
+ 	};
+ 	struct device *dev = &pdev->dev;
+ 	struct resource *res;


### PR DESCRIPTION
Actually, we don't need to disable gephy-thermal and top-glue-thermal to fix the infinite reboot issue. This problem stems from a change in the upstream Linux nvmem read policy on the IPQ platform. The newer kernel reads using a 4-byte-aligned-reads strategy, but this implementation has a bug in the 6.6 kernel. Adding a patch to revert this specific change will resolve the issue.