### PR TITLE
ipq50xx: select Redmi AX3000 BDF by PA type

### DIFF
--- a/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/10-ath11k-board_id
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/10-ath11k-board_id
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+[ -e /lib/firmware/$FIRMWARE ] && exit 0
+
+. /lib/functions.sh
+
+set_board_id() {
+	echo "$1" > /lib/firmware/$FIRMWARE
+}
+
+board=$(board_name)
+
+case "$FIRMWARE" in
+"ath11k/IPQ5018/hw1.0/board_id-ahb-c000000.wifi")
+	case "$board" in
+	redmi,ax3000)
+		case "$(strings /dev/mtdblock15 | sed -n 's/^wl_pa_type=//p' | head -n 1)" in
+		epa) set_board_id 0x24 ;;
+		xpa|ipa|*) set_board_id 0x10 ;;
+		esac
+		;;
+	esac
+	;;
+*)
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## Summary
- restore the ath11k board-id firmware hotplug selector for Redmi AX3000 variants
- select board ID `0x24` for `epa`
- select board ID `0x10` for `xpa`, `ipa`, and unknown PA types

## Problem
The shared device tree falls back to board ID `0x24`, but Redmi AX3000 variants use different 2.4 GHz PA/FEM layouts. A CR8809 reporting `wl_pa_type=xpa` consequently loaded the wrong BDF power/FEM table.

The ath11k filesystem board-id override support is already present, and the DTS comment references this hotplug script, but the script itself is missing from the qualcommax base files.

## Validation
Tested on Redmi/Xiaomi CR8809 with `wl_pa_type=xpa`:
- runtime board ID changed from `0x24` to `0x10`
- same-position phone RSSI improved from about -53 dBm to -30 dBm
- ath11k ACK RSSI stabilized around -32/-33 dBm
- no firmware crash or TX timeout after driver reload
- `epa` variants retain board ID `0x24`

Downstream validation PR: https://github.com/qwqgong-ui/Redmi_AX3000_immortalwrt/pull/2