### PR TITLE
mac80211: ath11k: fix RSSI for IPQ5018 and QCN6122

### DIFF
--- a/package/kernel/mac80211/patches/ath11k/947-wifi-ath11k-fix-rssi-station-dump-for-IPQ5018-and-QCN6122.patch
+++ b/package/kernel/mac80211/patches/ath11k/947-wifi-ath11k-fix-rssi-station-dump-for-IPQ5018-and-QCN6122.patch
@@ -1,0 +1,32 @@
+From 8fd48529849310a68500d1d546f246d44697bbed Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 25 Nov 2025 14:56:08 +0100
+Subject: [PATCH] wifi: ath11k: fix rssi station dump for IPQ5018 and QCN6122
+
+Commit 031ffa6c2cd3 ("wifi: ath11k: fix rssi station dump not updated in
+QCN9074") didn't account for IPQ5018 and QCN6122 WiFi card that are
+based on QCN9074.
+
+Update the .mpdu_info_get_peerid to use the QCN9074 variant to correctly
+receive consistent RSSI station data.
+
+Reported-by: Scott Mercer <TheRootEd24@gmail.com>
+Suggested-by: Scott Mercer <TheRootEd24@gmail.com>
+Tested-by: Scott Mercer <TheRootEd24@gmail.com>
+Fixes: 031ffa6c2cd3 ("wifi: ath11k: fix rssi station dump not updated in QCN9074")
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/net/wireless/ath/ath11k/hw.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/wireless/ath/ath11k/hw.c
++++ b/drivers/net/wireless/ath/ath11k/hw.c
+@@ -1175,7 +1175,7 @@ const struct ath11k_hw_ops ipq5018_ops =
+ 	.rx_desc_get_attention = ath11k_hw_qcn9074_rx_desc_get_attention,
+ 	.reo_setup = ath11k_hw_ipq5018_reo_setup,
+ 	.rx_desc_get_msdu_payload = ath11k_hw_qcn9074_rx_desc_get_msdu_payload,
+-	.mpdu_info_get_peerid = ath11k_hw_ipq8074_mpdu_info_get_peerid,
++	.mpdu_info_get_peerid = ath11k_hw_qcn9074_mpdu_info_get_peerid,
+ 	.rx_desc_mac_addr2_valid = ath11k_hw_ipq9074_rx_desc_mac_addr2_valid,
+ 	.rx_desc_mpdu_start_addr2 = ath11k_hw_ipq9074_rx_desc_mpdu_start_addr2,
+ 	.get_ring_selector = ath11k_hw_ipq8074_get_tcl_ring_selector,


### PR DESCRIPTION
## Summary

- backport OpenWrt commit `6065edf3b2d3bc905ff45f58534de7596c7b83a8`
- use the QCN9074 MPDU peer-ID parser for the IPQ5018/QCN6122 hardware ops
- keep the change limited to RSSI/station reporting; TX power and calibration are unchanged

## Root cause

IPQ5018 and QCN6122 use the QCN9074-style RX descriptor layout, but the IPQ5018 hardware ops select the IPQ8074 peer-ID parser. As a result, `iw station dump` can report stale or incorrect per-station RSSI values.

## Runtime validation

Tested on a Redmi AX3000 (IPQ5018 + QCN6122) running ImmortalWrt 24.10-SNAPSHOT `r33982-c0cdf3733a`, kernel 6.6.143. Client identifiers were omitted.

Eight consecutive `iw station dump` samples showed live updates:

- 2.4 GHz IPQ5018 AP: instantaneous RSSI changed from -42 to -36 dBm; average RSSI changed from -42 to -39 dBm; ACK RSSI also refreshed.
- 5 GHz QCN6122 STA: instantaneous RSSI changed from -77 to -66 dBm; average RSSI changed from -77 to -70 dBm; beacon and ACK RSSI remained plausible.
- Initial station snapshots reported zero TX retries and zero TX failures.

This confirms that both radios return plausible, updating station data instead of a stuck descriptor value.

## Scope and checks

- one ath11k patch file, 32 lines
- patch is already compiled, flashed, and exercised in the fork firmware above
- no additional rebuild was performed for this PR